### PR TITLE
Replace coastaldemigod/data-ingestion-service with aktosecurity/data-…

### DIFF
--- a/docker-compose-mini-runtime.yml
+++ b/docker-compose-mini-runtime.yml
@@ -100,7 +100,7 @@ services:
         max-file: "2"
     
   data-ingestion-service:
-    image: coastaldemigod/data-ingestion-service
+    image: aktosecurity/data-ingestion-service
     env_file: ./data-ingestion-docker.env
     restart: always
     ports:


### PR DESCRIPTION
…ingestion-service

Updated the Docker image reference for data-ingestion-service to use the official aktosecurity organization repository instead of the personal coastaldemigod repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)