### PR TITLE
Update Nginx minimal configuration to use double quotes for regex pat…

### DIFF
--- a/nginx/nginx-minimal.conf
+++ b/nginx/nginx-minimal.conf
@@ -14,7 +14,7 @@ server {
     }
 
     # List requests for token (for polling hit status): GET /token/{uuid}/requests
-    location ~ ^/token/[0-9a-fA-F-]{36}/requests$ {
+    location ~ "^/token/[0-9a-fA-F-]{36}/requests$" {
         proxy_pass http://webhook-site:80;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -24,7 +24,7 @@ server {
     }
 
     # Capture URL: /{uuid} or /{uuid}/... (any method)
-    location ~ ^/[0-9a-fA-F-]{36}(/.*)?$ {
+    location ~ "^/[0-9a-fA-F-]{36}(/.*)?$" {
         proxy_pass http://webhook-site:80;
         proxy_http_version 1.1;
         proxy_set_header Host $host;


### PR DESCRIPTION
…terns

- Modified regex patterns in nginx-minimal.conf to use double quotes for consistency and improved readability.
- Adjusted location blocks for token requests and UUID capture to ensure proper matching.